### PR TITLE
feat(ci): add multi-platform Docker builds for ARM64 support

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -55,8 +55,9 @@ jobs:
           echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
           echo "TAG_PREFIX=${TAG_PREFIX}" >> $GITHUB_ENV
 
-          # Build the Docker image
-          docker build --build-arg DB_HOST=${{ secrets.DB_HOST }} \
+          # Build the Docker image for multiple platforms
+          docker buildx build --platform linux/amd64,linux/arm64 \
+                       --build-arg DB_HOST=${{ secrets.DB_HOST }} \
                        --build-arg DB_USER=${{ secrets.DB_USER }} \
                        --build-arg DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
                        --build-arg DB_NAME=${{ secrets.DB_NAME }} \


### PR DESCRIPTION
# Summary\*

`Description`: Add multi-platform Docker build support to CI workflow for ARM64 compatibility with Raspberry Pi cluster. The workflow now builds images for both amd64 and arm64 architectures, ensuring the web scraper can run on Raspberry Pi nodes.

`Reasons for the change`:
1. ARM64 compatibility: Raspberry Pi cluster requires ARM64 images, current builds only support x86_64
2. Architecture mismatch: Web scraper jobs failing with `exec format error` due to wrong CPU architecture
3. Multi-platform support: Single image tag works across development machines (amd64) and production cluster (arm64)
4. Future-proofing: Enables deployment to mixed architecture environments

# Checklist\*

- [x] I have updated documentation where necessary
- [x] I have commented my code, particularly in hard-to-understand areas

# This PR includes the following changes\*

- [ ] feat: New Feature or update to existing feature
- [x] fix: bug fix
- [ ] refactor: refactoring of existing code
