### PR TITLE
fix(api): force IPv4-first DNS resolution to prevent database failures

### DIFF
--- a/api/src/config/database.ts
+++ b/api/src/config/database.ts
@@ -1,4 +1,8 @@
 import { Pool, PoolConfig } from 'pg';
+import * as dns from 'dns';
+
+// Force IPv4 resolution to avoid IPv6 connectivity issues
+dns.setDefaultResultOrder('ipv4first');
 
 const poolConfig: PoolConfig = {
   host: process.env.DATABASE_HOST || 'localhost',


### PR DESCRIPTION
# Summary\*

`Description`: This PR fixes database connectivity issues in the Salt API by forcing IPv4-first DNS resolution. The change affects `api/src/config/database.ts` and resolves intermittent 500 Internal Server Error responses when the API tries to connect to

`Reasons for the change`: The API was experiencing connection failures due to IPv6 DNS resolution attempts that were unreachable in the cluster environment. Node.js was attempting IPv6 connections first, causing `ENETUNREACH` errors before falling back to IPv4. This resulted in users seeing "Failed to load sessions" errors when they had no sessions in the database.

# Checklist\*

- [x] I have updated documentation where necessary
- [x] I have commented my code, particularly in hard-to-understand areas

# This PR includes the following changes\*

- [ ] feat: New Feature or update to existing feature
- [x] fix: bug fix
- [ ] refactor: refactoring of existing code
