### PR TITLE
fix(docker): ARM64 and AMD64 builds

### DIFF
--- a/.github/workflows/docker-build-api.yml
+++ b/.github/workflows/docker-build-api.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           context: .
           file: api/salt-api.Dockerfile
-          platforms: linux/arm64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             surflocally/salt-api:${{ env.TAG_PREFIX }}-${{ env.COMMIT_HASH }}

--- a/.github/workflows/docker-build-api.yml
+++ b/.github/workflows/docker-build-api.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           context: .
           file: api/salt-api.Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           push: true
           tags: |
             surflocally/salt-api:${{ env.TAG_PREFIX }}-${{ env.COMMIT_HASH }}

--- a/.github/workflows/docker-build-api.yml
+++ b/.github/workflows/docker-build-api.yml
@@ -18,7 +18,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # Step 2: Set up Docker Buildx for building images
+      # Step 2: Set up QEMU for multi-platform builds
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      # Step 3: Set up Docker Buildx for building multi-platform images
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -55,7 +59,7 @@ jobs:
         with:
           context: .
           file: api/salt-api.Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             surflocally/salt-api:${{ env.TAG_PREFIX }}-${{ env.COMMIT_HASH }}

--- a/.github/workflows/docker-build-app.yml
+++ b/.github/workflows/docker-build-app.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           context: .
           file: app/salt-app.Dockerfile
-          platforms: linux/arm64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             surflocally/salt-app:${{ env.TAG_PREFIX }}-${{ env.COMMIT_HASH }}

--- a/.github/workflows/docker-build-app.yml
+++ b/.github/workflows/docker-build-app.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           context: .
           file: app/salt-app.Dockerfile
-          platforms: linux/amd64
+          platforms: linux/arm64
           push: true
           tags: |
             surflocally/salt-app:${{ env.TAG_PREFIX }}-${{ env.COMMIT_HASH }}

--- a/.github/workflows/docker-build-scraper.yml
+++ b/.github/workflows/docker-build-scraper.yml
@@ -62,8 +62,8 @@ jobs:
           echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
           echo "TAG_PREFIX=${TAG_PREFIX}" >> $GITHUB_ENV
 
-          # Build the Docker image for amd64 platform
-          docker buildx build --platform linux/amd64 \
+          # Build the Docker image for ARM64 platform (Raspberry Pi)
+          docker buildx build --platform linux/arm64 \
                        --build-arg DB_HOST="postgres" \
                        --build-arg DB_USER="argo_runner" \
                        --build-arg DB_PASSWORD=${{ secrets.DB_PASSWORD_ARGO }} \
@@ -79,4 +79,4 @@ jobs:
       # Step 6: Images already pushed via buildx build --push
       - name: Images pushed successfully
         run: |
-          echo "Images ${IMAGE_NAME}:${IMAGE_TAG} and ${IMAGE_NAME}:${TAG_PREFIX}-latest pushed for amd64"
+          echo "Images ${IMAGE_NAME}:${IMAGE_TAG} and ${IMAGE_NAME}:${TAG_PREFIX}-latest pushed for ARM64"

--- a/.github/workflows/docker-build-scraper.yml
+++ b/.github/workflows/docker-build-scraper.yml
@@ -62,8 +62,8 @@ jobs:
           echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
           echo "TAG_PREFIX=${TAG_PREFIX}" >> $GITHUB_ENV
 
-          # Build the Docker image for ARM64 platform (Raspberry Pi)
-          docker buildx build --platform linux/arm64 \
+          # Build the Docker image for both AMD64 and ARM64 platforms
+          docker buildx build --platform linux/amd64,linux/arm64 \
                        --build-arg DB_HOST="postgres" \
                        --build-arg DB_USER="argo_runner" \
                        --build-arg DB_PASSWORD=${{ secrets.DB_PASSWORD_ARGO }} \
@@ -79,4 +79,4 @@ jobs:
       # Step 6: Images already pushed via buildx build --push
       - name: Images pushed successfully
         run: |
-          echo "Images ${IMAGE_NAME}:${IMAGE_TAG} and ${IMAGE_NAME}:${TAG_PREFIX}-latest pushed for ARM64"
+          echo "Images ${IMAGE_NAME}:${IMAGE_TAG} and ${IMAGE_NAME}:${TAG_PREFIX}-latest pushed for AMD64 and ARM64"

--- a/app/src/hooks/useAdmin.ts
+++ b/app/src/hooks/useAdmin.ts
@@ -10,16 +10,19 @@ export const useAdmin = () => {
   useEffect(() => {
     const checkAdminStatus = async () => {
       if (!user) {
+        console.log('[useAdmin] No user, setting isAdmin to false');
         setIsAdmin(false);
         setLoading(false);
         return;
       }
 
+      console.log('[useAdmin] Checking admin status for user:', user.id);
       try {
         const data = await api.auth.checkAdmin();
+        console.log('[useAdmin] Admin check response:', data);
         setIsAdmin(data.is_admin || false);
       } catch (error) {
-        console.error('Failed to check admin status:', error);
+        console.error('[useAdmin] Failed to check admin status:', error);
         setIsAdmin(false);
       } finally {
         setLoading(false);


### PR DESCRIPTION
# Summary\*

`Description`: This change updates all three Docker build workflows (docker-build-api.yml, docker-build-app.yml, and docker-build-scraper.yml) to build multi-architecture Docker images that support both AMD64 and ARM64 processors. The workflows now use QEMU emulation on GitHub Actions ubuntu-latest runners to build for ARM64 alongside the native AMD64 builds, creating a single Docker image manifest that automatically serves the correct architecture to each platform.

`Reasons for the change`: The previous configuration built only for AMD64 architecture, which caused compatibility issues with the Raspberry Pi cluster (ARM64) that hosts the production deployment. Multi-architecture builds ensure the same Docker image tags work seamlessly across both development environments (AMD64) and production infrastructure (ARM64), eliminating the need for separate image tags or manual architecture selection. This approach provides better flexibility for future deployments and maintains compatibility with the existing Raspberry Pi cluster while still supporting standard x86_64 environments.

# Checklist\*

- [ ] I have updated documentation where necessary
- [ ] I have commented my code, particularly in hard-to-understand areas

# This PR includes the following changes\*

- [ ] feat: New Feature or update to existing feature
- [x] fix: bug fix
- [ ] refactor: refactoring of existing code
