### PR TITLE
fix(api): remove admin button and mobile replies

### DIFF
--- a/api/src/routes/social.ts
+++ b/api/src/routes/social.ts
@@ -213,7 +213,8 @@ router.get('/search-profiles', asyncHandler(async (req, res) => {
             (SELECT COUNT(*) FROM sessions WHERE user_id = p.user_id) as session_count,
             (SELECT COUNT(*) FROM boards WHERE user_id = p.user_id) as board_count,
             (SELECT COUNT(*) FROM follows WHERE following_id = p.user_id) as follower_count,
-            (SELECT COUNT(*) FROM follows WHERE follower_id = p.user_id) as following_count
+            (SELECT COUNT(*) FROM follows WHERE follower_id = p.user_id) as following_count,
+            EXISTS(SELECT 1 FROM user_roles WHERE user_id = p.user_id AND role = 'admin') as is_admin
      FROM profiles p
      WHERE p.display_name ILIKE $1 OR p.bio ILIKE $1
      ORDER BY follower_count DESC

--- a/app/src/pages/SpotReports.tsx
+++ b/app/src/pages/SpotReports.tsx
@@ -2446,6 +2446,74 @@ const handleSpotClick = (spot: Spot) => {
                                       </button>
                                     )}
                                   </div>
+
+                                  {/* Reply Input - Mobile */}
+                                  {replyingTo === comment.id && (
+                                    <div className="flex gap-2 mt-3">
+                                      <Input
+                                        placeholder="Write a reply..."
+                                        value={replyContent}
+                                        onChange={(e) => setReplyContent(e.target.value)}
+                                        onKeyDown={(e) => e.key === 'Enter' && handleReply(comment.id)}
+                                        className="text-sm"
+                                        autoFocus
+                                      />
+                                      <Button size="sm" onClick={() => handleReply(comment.id)}>Reply</Button>
+                                      <Button size="sm" variant="ghost" onClick={() => { setReplyingTo(null); setReplyContent(''); }}>
+                                        <X className="h-4 w-4" />
+                                      </Button>
+                                    </div>
+                                  )}
+
+                                  {/* Replies - Mobile */}
+                                  {comment.replies && comment.replies.length > 0 && (
+                                    <div className="mt-3 space-y-2">
+                                      {comment.replies.map((reply) => (
+                                        <div key={reply.id} className="bg-muted/20 rounded-lg p-2 ml-4">
+                                          <div className="flex items-start gap-2">
+                                            <Avatar className="h-5 w-5">
+                                              <AvatarFallback className="bg-primary/10 text-primary text-xs">
+                                                {(reply.profile?.display_name || 'S')[0].toUpperCase()}
+                                              </AvatarFallback>
+                                            </Avatar>
+                                            <div className="flex-1 min-w-0">
+                                              <div className="flex items-center gap-2 flex-wrap">
+                                                <span className="font-medium text-xs text-foreground">{reply.profile?.display_name || 'Surfer'}</span>
+                                                <span className="text-xs text-muted-foreground">{formatCommentTime(reply.created_at)}</span>
+                                              </div>
+                                              <p className="text-xs text-foreground mt-1">{reply.content}</p>
+                                              <div className="flex items-center gap-2 mt-1">
+                                                <button 
+                                                  onClick={() => handleLikeComment(reply.id, reply.user_id, reply.is_liked)} 
+                                                  className={`flex items-center gap-1 text-xs transition-colors ${user?.id === reply.user_id ? 'opacity-30 cursor-not-allowed' : reply.is_liked ? 'opacity-100' : 'opacity-60 hover:opacity-100'}`}
+                                                  disabled={user?.id === reply.user_id}
+                                                >
+                                                  <img src={shakaIcon} alt="Shaka" className={`h-4 w-4 object-contain ${reply.is_liked ? 'scale-110' : ''} transition-transform`} />
+                                                  {reply.likes_count > 0 && reply.likes_count}
+                                                </button>
+                                                <button 
+                                                  onClick={() => handleKookComment(reply.id, reply.user_id, reply.is_kooked)} 
+                                                  className={`flex items-center gap-1 text-xs transition-colors ${user?.id === reply.user_id ? 'opacity-30 cursor-not-allowed' : reply.is_kooked ? 'opacity-100' : 'opacity-60 hover:opacity-100'}`}
+                                                  disabled={user?.id === reply.user_id}
+                                                >
+                                                  <img src={kookIcon} alt="Kook" className={`h-5 w-5 object-contain ${reply.is_kooked ? 'scale-110' : ''} transition-transform`} />
+                                                  {reply.kooks_count > 0 && reply.kooks_count}
+                                                </button>
+                                                {(user?.id === reply.user_id || isAdmin) && (
+                                                  <button 
+                                                    onClick={() => handleDeleteComment(reply.id, reply.user_id)} 
+                                                    className="text-xs text-destructive/60 hover:text-destructive p-1 ml-auto"
+                                                  >
+                                                    <Trash2 className="h-3 w-3" />
+                                                  </button>
+                                                )}
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      ))}
+                                    </div>
+                                  )}
                                 </div>
                               </div>
                             </div>


### PR DESCRIPTION
# Summary\*

`Description`: Remove admin button and mobile reply fixes.

`Reasons for the change`:
- Admin panel: Search results now include is_admin field, so the UI correctly shows "Remove Admin" for existing admins instead of "Make Admin"
- Mobile reply button: The mobile layout was completely missing the reply input section and replies display. Now when you tap Reply on mobile, the input field appears and you can submit a reply. Existing replies are also now visible on mobile.
# Checklist\*

- [ ] I have updated documentation where necessary
- [ ] I have commented my code, particularly in hard-to-understand areas

# This PR includes the following changes\*

- [ ] feat: New Feature or update to existing feature
- [x] fix: bug fix
- [ ] refactor: refactoring of existing code
