### PR TITLE
fix(app): mobile button press admin panel

### DIFF
--- a/app/src/pages/Admin.tsx
+++ b/app/src/pages/Admin.tsx
@@ -233,9 +233,9 @@ const Admin = () => {
                             <Button
                               variant="outline"
                               size="sm"
-                              onClick={() => handleRemoveAdmin(u.user_id)}
+                              onClick={(e) => { (e.currentTarget as HTMLButtonElement).blur(); handleRemoveAdmin(u.user_id); }}
                               disabled={u.user_id === user?.id}
-                              className="text-orange-500 border-orange-500/30 hover:bg-orange-500/10 flex-1 sm:flex-none"
+                              className="text-orange-500 border-orange-500/30 hover:bg-orange-500/10 active:bg-orange-500/20 flex-1 sm:flex-none"
                             >
                               <ShieldOff className="h-4 w-4 mr-1" />
                               Remove Admin
@@ -244,8 +244,8 @@ const Admin = () => {
                             <Button
                               variant="outline"
                               size="sm"
-                              onClick={() => handlePromoteToAdmin(u.user_id)}
-                              className="text-green-500 border-green-500/30 hover:bg-green-500/10 flex-1 sm:flex-none"
+                              onClick={(e) => { (e.currentTarget as HTMLButtonElement).blur(); handlePromoteToAdmin(u.user_id); }}
+                              className="text-green-500 border-green-500/30 hover:bg-green-500/10 active:bg-green-500/20 flex-1 sm:flex-none"
                             >
                               <Shield className="h-4 w-4 mr-1" />
                               Make Admin


### PR DESCRIPTION
# Summary\*

`Description`: This update fixes a mobile-specific UI issue in the Admin panel where the "Make Admin" and "Remove Admin" buttons would remain in a pressed state after being tapped on touch devices.

`Reasons for the change`:
- Mobile touch devices don't have true hover states, causing hover styles to persist after tap
- Buttons appeared stuck in pressed state, creating poor user experience on mobile
- The blur() method ensures the button focus is released immediately after interaction
- Active states provide appropriate visual feedback for touch interactions while maintaining desktop hover behavior

# Checklist\*

- [ ] I have updated documentation where necessary
- [x] I have commented my code, particularly in hard-to-understand areas

# This PR includes the following changes\*

- [ ] feat: New Feature or update to existing feature
- [x] fix: bug fix
- [ ] refactor: refactoring of existing code
