### PR TITLE
fix(app): mobile button pressed state persistence

### DIFF
--- a/app/src/pages/Admin.tsx
+++ b/app/src/pages/Admin.tsx
@@ -235,7 +235,7 @@ const Admin = () => {
                               size="sm"
                               onClick={(e) => { (e.currentTarget as HTMLButtonElement).blur(); handleRemoveAdmin(u.user_id); }}
                               disabled={u.user_id === user?.id}
-                              className="text-orange-500 border-orange-500/30 hover:bg-orange-500/10 active:bg-orange-500/20 flex-1 sm:flex-none"
+                              className="text-orange-500 border-orange-500/30 hover:!bg-orange-500/10 focus:!bg-transparent active:!bg-orange-500/20 flex-1 sm:flex-none"
                             >
                               <ShieldOff className="h-4 w-4 mr-1" />
                               Remove Admin
@@ -245,7 +245,7 @@ const Admin = () => {
                               variant="outline"
                               size="sm"
                               onClick={(e) => { (e.currentTarget as HTMLButtonElement).blur(); handlePromoteToAdmin(u.user_id); }}
-                              className="text-green-500 border-green-500/30 hover:bg-green-500/10 active:bg-green-500/20 flex-1 sm:flex-none"
+                              className="text-green-500 border-green-500/30 hover:!bg-green-500/10 focus:!bg-transparent active:!bg-green-500/20 flex-1 sm:flex-none"
                             >
                               <Shield className="h-4 w-4 mr-1" />
                               Make Admin


### PR DESCRIPTION
# Summary\*

`Description`: This update resolves a mobile UI issue where admin buttons would remain in a pressed/focused state after being tapped. The problem was caused by the Button component's variant hover styles having higher specificity than the custom classes.

`Reasons for the change`:
- Button component's variant hover styles were overriding custom hover classes
- Mobile touch devices don't have true hover, causing persistent pressed appearance
- Important modifiers (!) needed to override component-level style specificity
- Ensures consistent button behavior across mobile and desktop platforms

# Checklist\*

- [ ] I have updated documentation where necessary
- [ ] I have commented my code, particularly in hard-to-understand areas

# This PR includes the following changes\*

- [ ] feat: New Feature or update to existing feature
- [x] fix: bug fix
- [ ] refactor: refactoring of existing code
