### PR TITLE
feat(monitoring): add Traefik networking metrics dashboard

### DIFF
--- a/helm/grafana/dashboards/networking/01-total-requests.json
+++ b/helm/grafana/dashboards/networking/01-total-requests.json
@@ -1,0 +1,57 @@
+{
+  "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "color": {
+        "mode": "thresholds"
+      },
+      "mappings": [],
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "green",
+            "value": null
+          }
+        ]
+      },
+      "unit": "short"
+    },
+    "overrides": []
+  },
+  "gridPos": {
+    "h": 4,
+    "w": 6,
+    "x": 0,
+    "y": 0
+  },
+  "id": 1,
+  "options": {
+    "colorMode": "value",
+    "graphMode": "none",
+    "justifyMode": "auto",
+    "orientation": "auto",
+    "reduceOptions": {
+      "values": false,
+      "calcs": ["lastNotNull"],
+      "fields": ""
+    },
+    "textMode": "auto"
+  },
+  "pluginVersion": "10.2.3",
+  "targets": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "expr": "sum(traefik_service_requests_total{job=\"traefik\"})",
+      "refId": "A"
+    }
+  ],
+  "title": "Total Requests",
+  "type": "stat"
+}

--- a/helm/grafana/dashboards/networking/02-requests-per-second.json
+++ b/helm/grafana/dashboards/networking/02-requests-per-second.json
@@ -1,0 +1,88 @@
+{
+  "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "color": {
+        "mode": "palette-classic"
+      },
+      "custom": {
+        "axisCenteredZero": false,
+        "axisColorMode": "text",
+        "axisLabel": "",
+        "axisPlacement": "auto",
+        "barAlignment": 0,
+        "drawStyle": "line",
+        "fillOpacity": 10,
+        "gradientMode": "none",
+        "hideFrom": {
+          "tooltip": false,
+          "viz": false,
+          "legend": false
+        },
+        "lineInterpolation": "linear",
+        "lineWidth": 1,
+        "pointSize": 5,
+        "scaleDistribution": {
+          "type": "linear"
+        },
+        "showPoints": "never",
+        "spanNulls": false,
+        "stacking": {
+          "group": "A",
+          "mode": "none"
+        },
+        "thresholdsStyle": {
+          "mode": "off"
+        }
+      },
+      "mappings": [],
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "green",
+            "value": null
+          }
+        ]
+      },
+      "unit": "reqps"
+    },
+    "overrides": []
+  },
+  "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 0,
+    "y": 4
+  },
+  "id": 2,
+  "options": {
+    "legend": {
+      "calcs": ["mean", "max"],
+      "displayMode": "list",
+      "placement": "bottom",
+      "showLegend": true
+    },
+    "tooltip": {
+      "mode": "multi",
+      "sort": "none"
+    }
+  },
+  "pluginVersion": "10.2.3",
+  "targets": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "expr": "sum(rate(traefik_service_requests_total{job=\"traefik\"}[5m])) by (service)",
+      "legendFormat": "{{`{{service}}`}}",
+      "refId": "A"
+    }
+  ],
+  "title": "Requests per Second by Service",
+  "type": "timeseries"
+}

--- a/helm/grafana/dashboards/networking/03-response-status-codes.json
+++ b/helm/grafana/dashboards/networking/03-response-status-codes.json
@@ -1,0 +1,134 @@
+{
+  "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "color": {
+        "mode": "palette-classic"
+      },
+      "custom": {
+        "axisCenteredZero": false,
+        "axisColorMode": "text",
+        "axisLabel": "",
+        "axisPlacement": "auto",
+        "barAlignment": 0,
+        "drawStyle": "line",
+        "fillOpacity": 10,
+        "gradientMode": "none",
+        "hideFrom": {
+          "tooltip": false,
+          "viz": false,
+          "legend": false
+        },
+        "lineInterpolation": "linear",
+        "lineWidth": 1,
+        "pointSize": 5,
+        "scaleDistribution": {
+          "type": "linear"
+        },
+        "showPoints": "never",
+        "spanNulls": false,
+        "stacking": {
+          "group": "A",
+          "mode": "none"
+        },
+        "thresholdsStyle": {
+          "mode": "off"
+        }
+      },
+      "mappings": [],
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "green",
+            "value": null
+          }
+        ]
+      },
+      "unit": "reqps"
+    },
+    "overrides": [
+      {
+        "matcher": {
+          "id": "byRegexp",
+          "options": ".*5.."
+        },
+        "properties": [
+          {
+            "id": "color",
+            "value": {
+              "fixedColor": "red",
+              "mode": "fixed"
+            }
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byRegexp",
+          "options": ".*4.."
+        },
+        "properties": [
+          {
+            "id": "color",
+            "value": {
+              "fixedColor": "orange",
+              "mode": "fixed"
+            }
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byRegexp",
+          "options": ".*2.."
+        },
+        "properties": [
+          {
+            "id": "color",
+            "value": {
+              "fixedColor": "green",
+              "mode": "fixed"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 12,
+    "y": 4
+  },
+  "id": 3,
+  "options": {
+    "legend": {
+      "calcs": ["sum"],
+      "displayMode": "list",
+      "placement": "bottom",
+      "showLegend": true
+    },
+    "tooltip": {
+      "mode": "multi",
+      "sort": "none"
+    }
+  },
+  "pluginVersion": "10.2.3",
+  "targets": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "expr": "sum(rate(traefik_service_requests_total{job=\"traefik\"}[5m])) by (code)",
+      "legendFormat": "{{`{{code}}`}}",
+      "refId": "A"
+    }
+  ],
+  "title": "Response Status Codes",
+  "type": "timeseries"
+}

--- a/helm/grafana/dashboards/networking/04-5xx-errors.json
+++ b/helm/grafana/dashboards/networking/04-5xx-errors.json
@@ -1,0 +1,65 @@
+{
+  "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "color": {
+        "mode": "thresholds"
+      },
+      "mappings": [],
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "green",
+            "value": null
+          },
+          {
+            "color": "yellow",
+            "value": 1
+          },
+          {
+            "color": "red",
+            "value": 10
+          }
+        ]
+      },
+      "unit": "short"
+    },
+    "overrides": []
+  },
+  "gridPos": {
+    "h": 4,
+    "w": 6,
+    "x": 6,
+    "y": 0
+  },
+  "id": 4,
+  "options": {
+    "colorMode": "value",
+    "graphMode": "area",
+    "justifyMode": "auto",
+    "orientation": "auto",
+    "reduceOptions": {
+      "values": false,
+      "calcs": ["lastNotNull"],
+      "fields": ""
+    },
+    "textMode": "auto"
+  },
+  "pluginVersion": "10.2.3",
+  "targets": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "expr": "sum(increase(traefik_service_requests_total{job=\"traefik\",code=~\"5..\"}[1h]))",
+      "refId": "A"
+    }
+  ],
+  "title": "5xx Errors (1h)",
+  "type": "stat"
+}

--- a/helm/grafana/dashboards/networking/05-4xx-errors.json
+++ b/helm/grafana/dashboards/networking/05-4xx-errors.json
@@ -1,0 +1,65 @@
+{
+  "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "color": {
+        "mode": "thresholds"
+      },
+      "mappings": [],
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "green",
+            "value": null
+          },
+          {
+            "color": "yellow",
+            "value": 10
+          },
+          {
+            "color": "orange",
+            "value": 50
+          }
+        ]
+      },
+      "unit": "short"
+    },
+    "overrides": []
+  },
+  "gridPos": {
+    "h": 4,
+    "w": 6,
+    "x": 12,
+    "y": 0
+  },
+  "id": 5,
+  "options": {
+    "colorMode": "value",
+    "graphMode": "area",
+    "justifyMode": "auto",
+    "orientation": "auto",
+    "reduceOptions": {
+      "values": false,
+      "calcs": ["lastNotNull"],
+      "fields": ""
+    },
+    "textMode": "auto"
+  },
+  "pluginVersion": "10.2.3",
+  "targets": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "expr": "sum(increase(traefik_service_requests_total{job=\"traefik\",code=~\"4..\"}[1h]))",
+      "refId": "A"
+    }
+  ],
+  "title": "4xx Errors (1h)",
+  "type": "stat"
+}

--- a/helm/grafana/dashboards/networking/06-active-connections.json
+++ b/helm/grafana/dashboards/networking/06-active-connections.json
@@ -1,0 +1,65 @@
+{
+  "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "color": {
+        "mode": "thresholds"
+      },
+      "mappings": [],
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "green",
+            "value": null
+          },
+          {
+            "color": "yellow",
+            "value": 100
+          },
+          {
+            "color": "red",
+            "value": 500
+          }
+        ]
+      },
+      "unit": "short"
+    },
+    "overrides": []
+  },
+  "gridPos": {
+    "h": 4,
+    "w": 6,
+    "x": 18,
+    "y": 0
+  },
+  "id": 6,
+  "options": {
+    "colorMode": "value",
+    "graphMode": "area",
+    "justifyMode": "auto",
+    "orientation": "auto",
+    "reduceOptions": {
+      "values": false,
+      "calcs": ["lastNotNull"],
+      "fields": ""
+    },
+    "textMode": "auto"
+  },
+  "pluginVersion": "10.2.3",
+  "targets": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "expr": "sum(traefik_entrypoint_open_connections{job=\"traefik\"})",
+      "refId": "A"
+    }
+  ],
+  "title": "Active Connections",
+  "type": "stat"
+}

--- a/helm/grafana/dashboards/networking/07-request-duration.json
+++ b/helm/grafana/dashboards/networking/07-request-duration.json
@@ -1,0 +1,97 @@
+{
+  "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "color": {
+        "mode": "palette-classic"
+      },
+      "custom": {
+        "axisCenteredZero": false,
+        "axisColorMode": "text",
+        "axisLabel": "",
+        "axisPlacement": "auto",
+        "barAlignment": 0,
+        "drawStyle": "line",
+        "fillOpacity": 10,
+        "gradientMode": "none",
+        "hideFrom": {
+          "tooltip": false,
+          "viz": false,
+          "legend": false
+        },
+        "lineInterpolation": "linear",
+        "lineWidth": 1,
+        "pointSize": 5,
+        "scaleDistribution": {
+          "type": "linear"
+        },
+        "showPoints": "never",
+        "spanNulls": false,
+        "stacking": {
+          "group": "A",
+          "mode": "none"
+        },
+        "thresholdsStyle": {
+          "mode": "off"
+        }
+      },
+      "mappings": [],
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "green",
+            "value": null
+          }
+        ]
+      },
+      "unit": "s"
+    },
+    "overrides": []
+  },
+  "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 0,
+    "y": 12
+  },
+  "id": 7,
+  "options": {
+    "legend": {
+      "calcs": ["mean", "max"],
+      "displayMode": "list",
+      "placement": "bottom",
+      "showLegend": true
+    },
+    "tooltip": {
+      "mode": "multi",
+      "sort": "none"
+    }
+  },
+  "pluginVersion": "10.2.3",
+  "targets": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "expr": "histogram_quantile(0.95, sum(rate(traefik_service_request_duration_seconds_bucket{job=\"traefik\"}[5m])) by (le, service))",
+      "legendFormat": "{{`{{service}}`}} p95",
+      "refId": "A"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "expr": "histogram_quantile(0.50, sum(rate(traefik_service_request_duration_seconds_bucket{job=\"traefik\"}[5m])) by (le, service))",
+      "legendFormat": "{{`{{service}}`}} p50",
+      "refId": "B"
+    }
+  ],
+  "title": "Request Duration (p50/p95)",
+  "type": "timeseries"
+}

--- a/helm/grafana/dashboards/networking/08-entrypoint-requests.json
+++ b/helm/grafana/dashboards/networking/08-entrypoint-requests.json
@@ -1,0 +1,88 @@
+{
+  "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "color": {
+        "mode": "palette-classic"
+      },
+      "custom": {
+        "axisCenteredZero": false,
+        "axisColorMode": "text",
+        "axisLabel": "",
+        "axisPlacement": "auto",
+        "barAlignment": 0,
+        "drawStyle": "line",
+        "fillOpacity": 10,
+        "gradientMode": "none",
+        "hideFrom": {
+          "tooltip": false,
+          "viz": false,
+          "legend": false
+        },
+        "lineInterpolation": "linear",
+        "lineWidth": 1,
+        "pointSize": 5,
+        "scaleDistribution": {
+          "type": "linear"
+        },
+        "showPoints": "never",
+        "spanNulls": false,
+        "stacking": {
+          "group": "A",
+          "mode": "none"
+        },
+        "thresholdsStyle": {
+          "mode": "off"
+        }
+      },
+      "mappings": [],
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "green",
+            "value": null
+          }
+        ]
+      },
+      "unit": "reqps"
+    },
+    "overrides": []
+  },
+  "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 12,
+    "y": 12
+  },
+  "id": 8,
+  "options": {
+    "legend": {
+      "calcs": ["mean", "max"],
+      "displayMode": "list",
+      "placement": "bottom",
+      "showLegend": true
+    },
+    "tooltip": {
+      "mode": "multi",
+      "sort": "none"
+    }
+  },
+  "pluginVersion": "10.2.3",
+  "targets": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "expr": "sum(rate(traefik_entrypoint_requests_total{job=\"traefik\"}[5m])) by (entrypoint)",
+      "legendFormat": "{{`{{entrypoint}}`}}",
+      "refId": "A"
+    }
+  ],
+  "title": "Requests by Entrypoint (HTTP/HTTPS)",
+  "type": "timeseries"
+}

--- a/helm/grafana/dashboards/networking/09-error-rate.json
+++ b/helm/grafana/dashboards/networking/09-error-rate.json
@@ -1,0 +1,107 @@
+{
+  "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "color": {
+        "mode": "palette-classic"
+      },
+      "custom": {
+        "axisCenteredZero": false,
+        "axisColorMode": "text",
+        "axisLabel": "",
+        "axisPlacement": "auto",
+        "barAlignment": 0,
+        "drawStyle": "line",
+        "fillOpacity": 10,
+        "gradientMode": "none",
+        "hideFrom": {
+          "tooltip": false,
+          "viz": false,
+          "legend": false
+        },
+        "lineInterpolation": "linear",
+        "lineWidth": 2,
+        "pointSize": 5,
+        "scaleDistribution": {
+          "type": "linear"
+        },
+        "showPoints": "never",
+        "spanNulls": false,
+        "stacking": {
+          "group": "A",
+          "mode": "none"
+        },
+        "thresholdsStyle": {
+          "mode": "line"
+        }
+      },
+      "mappings": [],
+      "max": 100,
+      "min": 0,
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "green",
+            "value": null
+          },
+          {
+            "color": "yellow",
+            "value": 1
+          },
+          {
+            "color": "red",
+            "value": 5
+          }
+        ]
+      },
+      "unit": "percent"
+    },
+    "overrides": []
+  },
+  "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 0,
+    "y": 20
+  },
+  "id": 9,
+  "options": {
+    "legend": {
+      "calcs": ["mean", "max"],
+      "displayMode": "list",
+      "placement": "bottom",
+      "showLegend": true
+    },
+    "tooltip": {
+      "mode": "multi",
+      "sort": "none"
+    }
+  },
+  "pluginVersion": "10.2.3",
+  "targets": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "expr": "100 * sum(rate(traefik_service_requests_total{job=\"traefik\",code=~\"5..\"}[5m])) / sum(rate(traefik_service_requests_total{job=\"traefik\"}[5m]))",
+      "legendFormat": "5xx Error Rate",
+      "refId": "A"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "expr": "100 * sum(rate(traefik_service_requests_total{job=\"traefik\",code=~\"4..\"}[5m])) / sum(rate(traefik_service_requests_total{job=\"traefik\"}[5m]))",
+      "legendFormat": "4xx Error Rate",
+      "refId": "B"
+    }
+  ],
+  "title": "Error Rate (%)",
+  "type": "timeseries"
+}

--- a/helm/grafana/dashboards/networking/10-bytes-transferred.json
+++ b/helm/grafana/dashboards/networking/10-bytes-transferred.json
@@ -1,0 +1,97 @@
+{
+  "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "color": {
+        "mode": "palette-classic"
+      },
+      "custom": {
+        "axisCenteredZero": false,
+        "axisColorMode": "text",
+        "axisLabel": "",
+        "axisPlacement": "auto",
+        "barAlignment": 0,
+        "drawStyle": "line",
+        "fillOpacity": 10,
+        "gradientMode": "none",
+        "hideFrom": {
+          "tooltip": false,
+          "viz": false,
+          "legend": false
+        },
+        "lineInterpolation": "linear",
+        "lineWidth": 1,
+        "pointSize": 5,
+        "scaleDistribution": {
+          "type": "linear"
+        },
+        "showPoints": "never",
+        "spanNulls": false,
+        "stacking": {
+          "group": "A",
+          "mode": "none"
+        },
+        "thresholdsStyle": {
+          "mode": "off"
+        }
+      },
+      "mappings": [],
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "green",
+            "value": null
+          }
+        ]
+      },
+      "unit": "Bps"
+    },
+    "overrides": []
+  },
+  "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 12,
+    "y": 20
+  },
+  "id": 10,
+  "options": {
+    "legend": {
+      "calcs": ["mean", "max"],
+      "displayMode": "list",
+      "placement": "bottom",
+      "showLegend": true
+    },
+    "tooltip": {
+      "mode": "multi",
+      "sort": "none"
+    }
+  },
+  "pluginVersion": "10.2.3",
+  "targets": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "expr": "sum(rate(traefik_entrypoint_requests_bytes_total{job=\"traefik\"}[5m])) by (entrypoint)",
+      "legendFormat": "{{`{{entrypoint}}`}} In",
+      "refId": "A"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "expr": "sum(rate(traefik_entrypoint_responses_bytes_total{job=\"traefik\"}[5m])) by (entrypoint)",
+      "legendFormat": "{{`{{entrypoint}}`}} Out",
+      "refId": "B"
+    }
+  ],
+  "title": "Bytes Transferred",
+  "type": "timeseries"
+}

--- a/helm/grafana/dashboards/networking/_dashboard.json
+++ b/helm/grafana/dashboards/networking/_dashboard.json
@@ -1,0 +1,42 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [],
+  "refresh": "10s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["networking", "traefik", "ingress"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "{{ .Values.dashboards.networkingMetrics.title }}",
+  "uid": "networking-metrics",
+  "version": 1,
+  "weekStart": ""
+}

--- a/helm/grafana/templates/dashboard-networking-metrics.yaml
+++ b/helm/grafana/templates/dashboard-networking-metrics.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.dashboards.networkingMetrics.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "grafana.fullname" . }}-dashboard-networking
+  namespace: {{ .Values.metadata.namespace }}
+  labels:
+    {{- include "grafana.labels" . | nindent 4 }}
+    grafana_dashboard: "1"
+data:
+  networking-metrics.json: |
+    {{- $panels := list
+      "dashboards/networking/01-total-requests.json"
+      "dashboards/networking/02-requests-per-second.json"
+      "dashboards/networking/03-response-status-codes.json"
+      "dashboards/networking/04-5xx-errors.json"
+      "dashboards/networking/05-4xx-errors.json"
+      "dashboards/networking/06-active-connections.json"
+      "dashboards/networking/07-request-duration.json"
+      "dashboards/networking/08-entrypoint-requests.json"
+      "dashboards/networking/09-error-rate.json"
+      "dashboards/networking/10-bytes-transferred.json"
+    -}}
+    {{ include "grafana.assembleDashboard" (dict "base" "dashboards/networking/_dashboard.json" "panels" $panels "ctx" .) | nindent 4 }}
+{{- end }}

--- a/helm/grafana/templates/deployment.yaml
+++ b/helm/grafana/templates/deployment.yaml
@@ -123,3 +123,7 @@ spec:
           - configMap:
               name: {{ include "grafana.fullname" . }}-dashboard-postgres
           {{- end }}
+          {{- if .Values.dashboards.networkingMetrics.enabled }}
+          - configMap:
+              name: {{ include "grafana.fullname" . }}-dashboard-networking
+          {{- end }}

--- a/helm/grafana/values.yaml
+++ b/helm/grafana/values.yaml
@@ -146,6 +146,11 @@ dashboards:
   postgresMetrics:
     enabled: true
     title: "PostgreSQL - Database Metrics"
+  
+  # Networking/Traefik metrics dashboard
+  networkingMetrics:
+    enabled: true
+    title: "Networking - Traefik Ingress Metrics"
 
 # ==============================================================================
 # HEALTH CHECKS

--- a/helm/prometheus/templates/traefik-service.yaml
+++ b/helm/prometheus/templates/traefik-service.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.config.scrapeConfigs }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: traefik-metrics
+  namespace: kube-system
+  labels:
+    {{- include "prometheus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: traefik-metrics
+  {{- with .Values.metadata.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    app.kubernetes.io/name: traefik
+  ports:
+    - name: metrics
+      port: 9100
+      targetPort: 9100
+      protocol: TCP
+  type: ClusterIP
+{{- end }}

--- a/helm/prometheus/values.yaml
+++ b/helm/prometheus/values.yaml
@@ -151,6 +151,10 @@ config:
         - worker2:10250
         - worker3:10250
       metricsPath: /metrics/cadvisor
+    
+    - jobName: traefik
+      targets:
+        - traefik-metrics.kube-system.svc.cluster.local:9100
 
 # ==============================================================================
 # HEALTH CHECKS


### PR DESCRIPTION
# Summary\*

`Description`: This change adds comprehensive networking monitoring capabilities to the Salt cluster with a new Grafana dashboard for Traefik ingress metrics. The implementation includes 10 dashboard panels tracking request rates, error rates, latency, active connections, and bandwidth usage, along with the necessary Prometheus configuration to scrape Traefik metrics. Affected projects include the Prometheus and Grafana Helm charts, with new networking dashboard templates and Traefik metrics service configuration.

`Reasons for the change`:
- Provide visibility into ingress traffic patterns and performance metrics
- Enable proactive monitoring of HTTP errors (4xx/5xx) to detect issues quickly
- Track request latency (p50/p95) to ensure responsive user experience
- Monitor active connections and bandwidth usage for capacity planning
- Complete the observability stack for the HTTPS ingress setup
- Follow established Helm chart standards for maintainability

# Checklist\*

- [x] I have updated documentation where necessary
- [x] I have commented my code, particularly in hard-to-understand areas

# This PR includes the following changes\*

- [x] feat: New Feature or update to existing feature
- [ ] fix: bug fix
- [ ] refactor: refactoring of existing code
